### PR TITLE
rename WildFly Swarm to Thorntail

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You have to have Node.js 8.9.0+ installed. NPM comes automatically with Node.js.
 * `vertx`
 * `nodejs`
 * `springboot`
-* `wfswarm`
+* `thorntail`
 
 ## Before running the tests
 


### PR DESCRIPTION
The original `wfswarm` identifier isn't used anywhere, so
this is just an update to the README to make sure noone uses
the old identifier anymore. The new identifier is `thorntail`.